### PR TITLE
Filter out items without a name tag

### DIFF
--- a/app/Services/Overpass.php
+++ b/app/Services/Overpass.php
@@ -171,7 +171,7 @@ OVERPASS;
         $value = $type->tags[0]['value'];
 
         $innerQuery = sprintf('area(%d);', $area->idInfo->getAreaId());
-        $innerQuery .= sprintf('nwr["%s"="%s"](area);', $key, $value);
+        $innerQuery .= sprintf('nwr["%s"="%s"][name](area);', $key, $value);
 
         $result = [];
         $data = $this->cachedRunQuery($innerQuery);


### PR DESCRIPTION
Objects should always have at least a name tag with the local name.

There are currently lots of objects with only name:en in Addis Ababa - this needs to be corrected.