### PR TITLE
Version fragment URLs with the page's data timestamp

### DIFF
--- a/app/Http/Controllers/BranchDataController.php
+++ b/app/Http/Controllers/BranchDataController.php
@@ -10,8 +10,10 @@ use Illuminate\Support\Facades\Log;
  * Serves per-branch Mapillary images and Mangrove reviews as small HTML
  * fragments that are lazy-loaded by the browser when a branch scrolls into
  * view. This keeps the main place page from making dozens of upstream API
- * calls up front. The fragment responses carry the same public cache headers
- * as the pages themselves (see routes/web.php), so they are full-page cached.
+ * calls up front. The fragment responses are cached long-term without
+ * revalidation; their URLs carry the embedding page's data version, which
+ * both busts the browser cache and makes the data cache refetch anything
+ * older (see Cache::getFragmentCacheMiddleware and Cache::remember).
  */
 class BranchDataController extends Controller
 {

--- a/app/Http/Controllers/CacheController.php
+++ b/app/Http/Controllers/CacheController.php
@@ -12,11 +12,12 @@ use Illuminate\Support\Str;
  *
  * The flush itself happens lazily during the redirected page render: the
  * `refresh-cache` query param makes App\Services\Cache::remember() forget the
- * keys the page (and its lazy Mapillary/Mangrove fragments) touch. Because the
- * data cache is shared, the flush reaches every user: their stored copies
- * revalidate on the next load and pick up the fresh content (see
- * App\Services\Cache::getCacheMiddleware). The param's unique value gives the
- * flushing visitor an unconditional fresh response right away.
+ * keys that page render touches, giving it a fresh data version. The lazy
+ * Mapillary/Mangrove fragments follow via that version in their URLs (see
+ * Cache::remember), and because the data cache is shared the flush reaches
+ * every user: their stored page copies revalidate on the next load (see
+ * Cache::getCacheMiddleware). The param's unique value gives the flushing
+ * visitor an unconditional fresh response right away.
  */
 class CacheController extends Controller
 {

--- a/app/Services/Cache.php
+++ b/app/Services/Cache.php
@@ -17,18 +17,32 @@ class Cache
     private static ?int $oldestStoredAt = null;
 
     /**
-     * HTTP caching for pages and fragments: any cache (browser or shared) may
-     * store the response but must revalidate it on every use. While the
-     * server-side data cache is unchanged that revalidation is a cheap 304
-     * (the ETag is derived from the rendered content, which only changes when
-     * the data does); once anyone flushes it via the "Refresh data" button,
-     * every other user picks up the fresh content on their next page load
-     * instead of after a fixed max-age. The upstream APIs stay protected by
-     * the server-side data cache (LIFETIME / SHORT_LIFETIME) either way.
+     * HTTP caching for pages: any cache (browser or shared) may store the
+     * response but must revalidate it on every use. While the server-side
+     * data cache is unchanged that revalidation is a cheap 304 (the ETag is
+     * derived from the rendered content, which only changes when the data
+     * does); once anyone flushes it via the "Refresh data" button, every
+     * other user picks up the fresh content on their next page load instead
+     * of after a fixed max-age. The upstream APIs stay protected by the
+     * server-side data cache (LIFETIME / SHORT_LIFETIME) either way.
      */
     public static function getCacheMiddleware(): string
     {
         return 'cache.headers:public;no_cache;etag';
+    }
+
+    /**
+     * HTTP caching for the lazy-loaded fragments: unlike the pages they can
+     * be cached without revalidating, because their URLs are versioned with
+     * the embedding page's data version (lazyload.js appends `v`, see
+     * remember() for how the server honours it). When the page's data
+     * refreshes - via the "Refresh data" button or natural expiry - its
+     * content changes, every user's next page revalidation delivers new
+     * fragment URLs, and the old cached fragments simply fall out of use.
+     */
+    public static function getFragmentCacheMiddleware(): string
+    {
+        return 'cache.headers:public;max_age=' . self::LIFETIME;
     }
 
     public static function remember(string $key, \Closure $callback, int $lifetime = self::LIFETIME): mixed
@@ -47,18 +61,41 @@ class Cache
             }
         }
 
-        $entry = CacheFacade::remember($key, $lifetime, function () use ($callback) {
+        $wrap = function () use ($callback) {
             return ['storedAt' => time(), 'value' => $callback()];
-        });
+        };
+
+        $entry = CacheFacade::remember($key, $lifetime, $wrap);
 
         // Entries written before values were wrapped with storedAt.
         if (!is_array($entry) || !array_key_exists('storedAt', $entry) || !array_key_exists('value', $entry)) {
             return $entry;
         }
 
+        // Fragment requests carry the data version of the page that embedded
+        // them (`v`, appended by lazyload.js from the page's oldest storedAt):
+        // data older than that page must be refetched, so a fragment is never
+        // staler than the page claiming it - this is also what propagates a
+        // "Refresh data" flush to the fragments' own cache keys.
+        if ($entry['storedAt'] < self::requestedDataVersion() && !isset($flushedKeys[$key])) {
+            CacheFacade::forget($key);
+            $flushedKeys[$key] = true;
+            $entry = CacheFacade::remember($key, $lifetime, $wrap);
+        }
+
         self::$oldestStoredAt = min(self::$oldestStoredAt ?? PHP_INT_MAX, $entry['storedAt']);
 
         return $entry['value'];
+    }
+
+    /**
+     * The minimum data freshness requested via the `v` query param (a unix
+     * timestamp), clamped to the present so a forged future version cannot
+     * bust the cache on every request. 0 when absent, i.e. no requirement.
+     */
+    private static function requestedDataVersion(): int
+    {
+        return min((int) request()->query('v'), time());
     }
 
     public static function getOldestStoredAt(): ?int
@@ -71,10 +108,11 @@ class Cache
      * `Cache-Control: no-cache` on Ctrl+F5, which mobile browsers can't) or by
      * the `refresh-cache` query param behind the footer "Refresh data" button.
      * The param's unique value also guarantees the flushing visitor an
-     * unconditional fresh response (no stored entry, so no 304), for the page
-     * and its lazy-loaded Mapillary/Mangrove fragments alike; everyone else
-     * gets the refreshed data when their cached copy next revalidates against
-     * the flushed data cache (see getCacheMiddleware).
+     * unconditional fresh page response (no stored entry, so no 304). The
+     * flush only reaches the keys this page render touches; the fragments'
+     * own keys follow via the data version their new URLs carry (see
+     * remember()), and everyone else gets the refreshed data when their
+     * cached page copy next revalidates (see getCacheMiddleware).
      */
     public static function flushRequested(): bool
     {

--- a/resources/js/lazyload.js
+++ b/resources/js/lazyload.js
@@ -6,20 +6,24 @@
  * API requests on initial page load for places with many branches.
  */
 
-// When the page was opened via the footer "Refresh data" button it carries a
-// `refresh-cache` param. Capture it once, before we scrub it from the address
-// bar, so the same flush is propagated to the lazy fragment requests below —
-// otherwise their Mapillary/Mangrove data (and the browser's HTTP cache of it)
-// would stay stale.
+// The page was opened via the footer "Refresh data" button when it carries a
+// `refresh-cache` param; scrub it so it isn't bookmarked or shared. The flush
+// itself already happened server-side while this page was rendered.
 const REFRESH_PARAM = 'refresh-cache';
-const refreshCacheBuster = new URLSearchParams(window.location.search).get(REFRESH_PARAM);
 
 function scrubRefreshParam() {
-    if (refreshCacheBuster === null) return;
     const url = new URL(window.location.href);
+    if (!url.searchParams.has(REFRESH_PARAM)) return;
     url.searchParams.delete(REFRESH_PARAM);
     window.history.replaceState(window.history.state, '', url.toString());
 }
+
+// The page's data version (its oldest storedAt, see the layout's meta tag).
+// Appended to the fragment URLs as `v`: it versions the browser's HTTP cache
+// of the long-max-age fragment responses, and the server refetches fragment
+// data older than this page (see App\Services\Cache::remember) — which is
+// also how a "Refresh data" flush reaches the fragments.
+const dataVersion = document.querySelector('meta[name="opg-data-version"]')?.content;
 
 async function loadFragment(el) {
     const src = el.dataset.lazySrc;
@@ -28,12 +32,9 @@ async function loadFragment(el) {
     // Mark as loading so it is never observed/loaded twice.
     delete el.dataset.lazySrc;
 
-    // Propagate the cache flush to the fragment endpoint. The unique value also
-    // guarantees an unconditional fresh response instead of a revalidated 304
-    // (see App\Services\Cache::getCacheMiddleware).
     const url = new URL(src, window.location.origin);
-    if (refreshCacheBuster !== null) {
-        url.searchParams.set(REFRESH_PARAM, refreshCacheBuster);
+    if (dataVersion) {
+        url.searchParams.set('v', dataVersion);
     }
 
     try {

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -17,6 +17,13 @@
     @if(isset($schemaMarkup))
         {!! (new \App\Services\SchemaOrg(\App\Services\Repository::getInstance()))->renderJsonLd($schemaMarkup) !!}
     @endif
+    {{-- The page's data version (its oldest storedAt, also shown in the
+         footer). lazyload.js appends it as `v` to the fragment URLs so the
+         fragments are never staler than this page (see Cache::remember).
+         Final here because Blade renders the layout after the content. --}}
+    @if($dataVersion = \App\Services\Cache::getOldestStoredAt())
+        <meta name="opg-data-version" content="{{ $dataVersion }}">
+    @endif
 </head>
 <body class="bg-paper text-ink font-sans antialiased min-h-screen flex flex-col">
 <div class="h-1.5 bg-accent" aria-hidden="true"></div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,8 +25,9 @@ Route::post('/refresh-cache', [CacheController::class, 'refresh'])
     ->name('refreshCache');
 
 // Lazy-loaded, per-branch fragments (Mapillary images / Mangrove reviews).
-// Same public revalidation headers as the pages (see Cache::getCacheMiddleware).
-Route::middleware(\App\Services\Cache::getCacheMiddleware())
+// Cached without revalidation: their URLs are versioned by the embedding
+// page's data version (see Cache::getFragmentCacheMiddleware).
+Route::middleware(\App\Services\Cache::getFragmentCacheMiddleware())
     ->group(function() {
         Route::get('/api/branch/{lat}/{lon}/mapillary', [\App\Http\Controllers\BranchDataController::class, 'mapillary'])
             ->name('branch.mapillary');

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Http\Controllers\PageController;
+use App\Services\Cache;
+use Illuminate\Support\Facades\Cache as CacheFacade;
 use Tests\TestCase;
 
 class RoutesTest extends TestCase
@@ -42,18 +44,48 @@ class RoutesTest extends TestCase
     /**
      * Pages must revalidate on every use instead of being served stale from
      * HTTP caches, so a "Refresh data" flush reaches other users too (#65):
-     * unchanged content answers 304, flushed content a fresh 200.
+     * unchanged content answers 304, flushed content a fresh 200. The page
+     * also embeds its data version, which versions the fragment URLs.
      */
     public function testPagesRevalidateWithEtag(): void
     {
         $response = $this->get('/nefas-silk');
         $response->assertStatus(200);
         $response->assertHeader('Cache-Control', 'no-cache, public');
+        $response->assertSee('name="opg-data-version"', false);
         $etag = $response->headers->get('ETag');
         $this->assertNotNull($etag);
 
         $revalidation = $this->get('/nefas-silk', ['If-None-Match' => $etag]);
         $revalidation->assertStatus(304);
+    }
+
+    /**
+     * Fragments are cached without revalidation - their freshness comes from
+     * the page data version (`v`) in their URLs instead (see
+     * Cache::getFragmentCacheMiddleware).
+     */
+    public function testFragmentsAreCachedWithMaxAge(): void
+    {
+        $response = $this->get('/api/branch/8.9901018/38.7845284/mapillary');
+        $response->assertStatus(200);
+        $response->assertHeader('Cache-Control', 'max-age=86400, public');
+    }
+
+    /**
+     * The `v` query param is a minimum-freshness requirement: cached data
+     * older than the page that embedded the fragment URL is refetched, so a
+     * "Refresh data" flush reaches the fragments' own cache keys too (#65).
+     */
+    public function testDataVersionRefetchesOlderEntries(): void
+    {
+        CacheFacade::put('routes-test-version', ['storedAt' => time() - 100, 'value' => 'stale'], 60);
+
+        request()->query->set('v', (string) time());
+        $value = Cache::remember('routes-test-version', fn () => 'fresh', 60);
+
+        $this->assertSame('fresh', $value);
+        CacheFacade::forget('routes-test-version');
     }
 
     public function testSitemapContainsNewsfeeds(): void


### PR DESCRIPTION
Replace ETag revalidation on the lazy Mapillary/Mangrove fragments with long-lived caching (max-age) plus a version param: the page embeds its data version (the oldest storedAt of its cache reads, already shown in the footer) in a meta tag, and lazyload.js appends it to the fragment URLs as `v`. The server treats `v` as a minimum-freshness requirement - Cache::remember() refetches entries older than the page that embedded the URL - so fragments are never staler than their page and a "Refresh data" flush reaches the fragments' own cache keys without the previous refresh-cache param propagation.

Repeat views now make zero fragment requests instead of one revalidation each. Pages keep no-cache + ETag: that revalidation is what delivers the new fragment URLs to every user after a flush. The trade-off is that fragment updates from natural backend-cache expiry are quantized to page-version changes (bounded by the page data's 24h lifetime).